### PR TITLE
Update grpc with our compiler additions

### DIFF
--- a/src/compiler/php_generator.cc
+++ b/src/compiler/php_generator.cc
@@ -296,6 +296,15 @@ void PrintService(const ServiceDescriptor* service,
   out->Outdent();
   out->Print("}\n\n");
 
+  // getServiceName() -> string - The name of the gRPC service
+  map<grpc::string, grpc::string> service_vars;
+  service_vars["service_name"] = service->full_name();
+  out->Print("public function getServiceName() {\n");
+  out->Indent();
+  out->Print(service_vars, "return '$service_name$';\n");
+  out->Outdent();
+  out->Print("}\n\n");
+
   if (!is_server) {
     out->Print(
         "/**\n * @param string $$hostname hostname\n"


### PR DESCRIPTION
## What?

Rebases with grpc/grpc, and adds in our compiler additions for PHP services, which adds a `getServiceName` method to PHP generated clients.

(We already did this with `getExpectedResponseMessages` back in 2017.)